### PR TITLE
Update regexp to avoid duplicate ansible.cfg entries

### DIFF
--- a/roles/ansible-config/tasks/main.yml
+++ b/roles/ansible-config/tasks/main.yml
@@ -2,11 +2,11 @@
 - name: enable profile_tasks callback plugin
   lineinfile:
     path: /etc/ansible/ansible.cfg
-    regexp: '^#callback_whitelist'
+    regexp: '^.*callback_whitelist'
     line: 'callback_whitelist = profile_tasks'
 
 - name: disable host key checking
   lineinfile: 
     path: /etc/ansible/ansible.cfg
-    regexp: '^#host_key_checking'
+    regexp: '^.*host_key_checking'
     line: 'host_key_checking = False'


### PR DESCRIPTION
Running the ocp.yml playbook twice results in extra lines in ansible.cfg.   Remove the # from the regexp since it won't exist the second time the playbook is run.

@chaitanyaenr PTAL