### PR TITLE
Open more ports for uperf

### DIFF
--- a/roles/post-install/tasks/main.yml
+++ b/roles/post-install/tasks/main.yml
@@ -23,12 +23,12 @@
     - name: get the public ip of the master
       shell: aws ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId,Tags[?Key==`Name`].Value|[0],State.Name,PrivateIpAddress,PublicIpAddress, PrivateDnsName]' --output text | column -t | grep {{ OPENSHIFT_INSTALL_CLUSTER_NAME }} | grep {{ master_node.stdout }} | awk '{print $5}'
       register: master_public_ip
-    
+
     - name: get the private ip of the controller
       shell: aws ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId,Tags[?Key==`Name`].Value|[0],State.Name,PrivateIpAddress,PublicIpAddress, PrivateDnsName]' --output text | column -t | grep {{ OPENSHIFT_INSTALL_CLUSTER_NAME }} | grep {{ controller_node.stdout }} | awk '{print $6}'
       register: controller_private_ip
-    
-    - name: add controller to group         i      
+
+    - name: add controller to group
       add_host: name={{ controller_private_ip.stdout }} groups=controller
 
     - name: set controller host as fact
@@ -63,6 +63,19 @@
 
     - name: add inbound rule to allow udp traffic on port range 20000 to 20100
       shell: aws ec2 authorize-security-group-ingress --group-id {{ item }} --protocol udp --port 20000-20100 --cidr 0.0.0.0/0
+      with_items:
+        - "{{ security_groups.stdout_lines }}"
+      ignore_errors: yes
+
+    # uperf needs more ports for its control port which is choosen at random thus, open a very large range to facilitate this test
+    - name: add inbound rule to allow tcp traffic on port range 40000 to 65535
+      shell: aws ec2 authorize-security-group-ingress --group-id {{ item }} --protocol tcp --port 40000-65535 --cidr 0.0.0.0/0
+      with_items:
+        - "{{ security_groups.stdout_lines }}"
+      ignore_errors: yes
+
+    - name: add inbound rule to allow udp traffic on port range 40000 to 65535
+      shell: aws ec2 authorize-security-group-ingress --group-id {{ item }} --protocol udp --port 40000-65535 --cidr 0.0.0.0/0
       with_items:
         - "{{ security_groups.stdout_lines }}"
       ignore_errors: yes


### PR DESCRIPTION
uperf uses a control port that can not be passed in a cli arg, thus we must open
a very large range to ensure this port can pass traffic for uperf