### PR TITLE
Modify the automation to deal with non public master node ip's

### DIFF
--- a/roles/post-install/tasks/main.yml
+++ b/roles/post-install/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: pick one master node
-  shell: oc get nodes -l node-role.kubernetes.io/master | awk 'NR>1 {print $1}' | tail -n1
-  register: master_node
-
 - name: get the controller node
   shell: oc get nodes -l node-role.kubernetes.io/pbench="" | awk 'NR>1 {print $1}' | tail -n1
   register: controller_node
@@ -20,9 +16,9 @@
   shell: oc adm taint node {{ controller_node.stdout }} role=controller:NoSchedule
 
 - block:
-    - name: get the public ip of the master
-      shell: aws ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId,Tags[?Key==`Name`].Value|[0],State.Name,PrivateIpAddress,PublicIpAddress, PrivateDnsName]' --output text | column -t | grep {{ OPENSHIFT_INSTALL_CLUSTER_NAME }} | grep {{ master_node.stdout }} | awk '{print $5}'
-      register: master_public_ip
+    - name: get the public ip of the pbench controller
+      shell: aws ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId,Tags[?Key==`Name`].Value|[0],State.Name,PrivateIpAddress,PublicIpAddress, PrivateDnsName]' --output text | column -t | grep {{ OPENSHIFT_INSTALL_CLUSTER_NAME }} | grep {{ controller_node.stdout }} | awk '{print $5}'
+      register: controller_public_ip
 
     - name: get the private ip of the controller
       shell: aws ec2 describe-instances --query 'Reservations[*].Instances[*].[InstanceId,Tags[?Key==`Name`].Value|[0],State.Name,PrivateIpAddress,PublicIpAddress, PrivateDnsName]' --output text | column -t | grep {{ OPENSHIFT_INSTALL_CLUSTER_NAME }} | grep {{ controller_node.stdout }} | awk '{print $6}'

--- a/roles/post-install/templates/ssh-config.j2
+++ b/roles/post-install/templates/ssh-config.j2
@@ -1,6 +1,6 @@
 Host ip*
    StrictHostKeyChecking no
-   ProxyCommand ssh -W %h:%p {{ master_public_ip.stdout }}
+   ProxyCommand ssh -W %h:%p {{ controller_public_ip.stdout }}
    UserKnownHostsFile=/dev/null
    User core
 

--- a/roles/rhcos-post-install/tasks/main.yml
+++ b/roles/rhcos-post-install/tasks/main.yml
@@ -19,6 +19,10 @@
     {%raw%}oc get machineset -n openshift-machine-api -o=go-template='{{(index .items 0).spec.template.spec.providerSpec.value.placement.region}}'{%endraw%}
   register: rhcos_region
 
+- name: Get public subnet name
+  shell: aws ec2 describe-subnets --filters "Name=tag:kubernetes.io/cluster/{{ OPENSHIFT_INSTALL_CLUSTER_NAME }},Values=owned" "Name=cidrBlock,Values=10.0.0.0/20" | grep "Name" | awk '{print $3}'
+  register: rhcos_cluster_public_subnet
+
 - name: Place machineset yamls on master
   template:
     src: "{{item.src}}"

--- a/roles/rhcos-post-install/templates/pbench-node-machineset.yml.j2
+++ b/roles/rhcos-post-install/templates/pbench-node-machineset.yml.j2
@@ -49,7 +49,7 @@ items:
             placement:
               availabilityZone: {{rhcos_region.stdout}}a
               region: {{rhcos_region.stdout}}
-            publicIp: false
+            publicIp: true
             securityGroups:
             - filters:
               - name: tag:Name
@@ -59,7 +59,7 @@ items:
               filters:
               - name: tag:Name
                 values:
-                - {{rhcos_cluster_name.stdout}}-private-{{rhcos_region.stdout}}a
+                - {{ rhcos_cluster_public_subnet.stdout }}
             tags:
             - name: openshiftClusterID
               value: {{rhcos_cluster_id.stdout}}


### PR DESCRIPTION
With the latest changes to the ocp 4.0 installer, master nodes are
no longer publicly accessible. This commit assigns a public ip to
the pbench node created post-install and uses it to proxy the commands.