### PR TITLE
Allow incoming traffic on port 22 from 0.0.0.0/0

### DIFF
--- a/roles/install/tasks/main.yml
+++ b/roles/install/tasks/main.yml
@@ -121,7 +121,7 @@
   when: OPENSHIFT_INSTALL_PLATFORM == "libvirt"
 
 - block:
-    - name: run openshift installer on aws
+    - name: run openshift installer on aws using the image override
       shell: |
         set -o pipefail
         cd {{ workdir }}
@@ -130,7 +130,7 @@
         bin/openshift-install create cluster --log-level=debug 2>&1 | tee -a {{ OPENSHIFT_INSTALL_LOG_DIR }}/install.log
       when: (OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE is defined) and (OPENSHIFT_INSTALL_RELEASE_IMAGE_OVERRIDE != "")
 
-    - name: run openshift installer on aws
+    - name: run openshift installer on aws using the default release image
       shell: |
         set -o pipefail
         cd {{ workdir }}

--- a/roles/post-install/tasks/main.yml
+++ b/roles/post-install/tasks/main.yml
@@ -45,6 +45,12 @@
         - "{{ security_groups.stdout_lines }}"
       ignore_errors: yes
 
+    - name: add inbound rule to allow traffic on 22
+      shell: aws ec2 authorize-security-group-ingress --group-id {{ item }} --protocol tcp --port 22 --cidr 0.0.0.0/0
+      with_items:
+        - "{{ security_groups.stdout_lines }}"
+      ignore_errors: yes
+
     - name: add inbound rule to allow traffic on 9090
       shell: aws ec2 authorize-security-group-ingress --group-id {{ item }} --protocol tcp --port 9090 --cidr 0.0.0.0/0
       with_items:


### PR DESCRIPTION
The worker node's security group is allowing traffic only from a
limited source which was not the case before. This commit fixes it.