### PR TITLE
Adding extra dependencies & overwrite for taints.

### DIFF
--- a/roles/install/tasks/main.yml
+++ b/roles/install/tasks/main.yml
@@ -9,6 +9,8 @@
     - git
     - golang-bin
     - gcc-c++
+    - jq
+    - openshift-clients
     - python-pip
 
 - name: Install awscli

--- a/roles/post-install/tasks/main.yml
+++ b/roles/post-install/tasks/main.yml
@@ -14,7 +14,7 @@
     - "role=controller"
 
 - name: add a taint to the controller
-  shell: oc adm taint node {{ controller_node.stdout }} role=controller:NoSchedule
+  shell: oc adm taint node {{ controller_node.stdout }} role=controller:NoSchedule --overwrite=true
 
 - block:
     - name: get the public ip of the pbench controller


### PR DESCRIPTION
Without jq and openshift-clients post install fails.  I believe it is useful to have this as dependencies or at least check & warn the user if they're not available.